### PR TITLE
Fixed persist with nullable ids for entities & JsonSerializeFields.serialize

### DIFF
--- a/src/Creation/FromDbStrategy.php
+++ b/src/Creation/FromDbStrategy.php
@@ -73,7 +73,7 @@ class FromDbStrategy implements CreationStrategy
         continue;
       }
       foreach ($id as $field => $value) {
-        if ($entity->$field !== $value) {
+        if (null === $value || $entity->$field !== $value) {
           continue 2;
         }
       }

--- a/test/Unit/Util/JsonSerializeFields.php
+++ b/test/Unit/Util/JsonSerializeFields.php
@@ -18,7 +18,7 @@ trait JsonSerializeFields
     }, []);
   }
 
-  protected static function serialize($val): array
+  protected static function serialize($val)
   {
     if ($val instanceof Collection) {
       $val = $val->toArray();


### PR DESCRIPTION
1. [fix] Fix returned type from JsonSerializeFields.serialize: 
Issue with persist entities like ['id' => null, ...]
2. [fix] fixed persist with nullable ids for entities
